### PR TITLE
Ignore build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,5 @@ samples
 test
 test-helpers
 usage-tests
-src
 .travis.yml
 .gitignore

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "babel-plugin-rewire",
   "version": "1.2.1",
   "description": "A babel plugin adding the ability to rewire module dependencies. This enables to mock modules for testing purposes.",
-  "main": "lib/babel-plugin-rewire.js",
+  "main": "src/babel-plugin-rewire.js",
   "scripts": {
     "test": "./node_modules/.bin/mocha && ./node_modules/.bin/mocha usage-tests",
     "build": "./node_modules/.bin/babel src --out-dir lib",


### PR DESCRIPTION
just serve src so build and publish is not required.
The package can be used directly from github